### PR TITLE
add a GUI server launcher

### DIFF
--- a/server_launcher.py
+++ b/server_launcher.py
@@ -1,0 +1,206 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Tuple
+import json
+import os
+import sys
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+
+class ModelType(Enum):
+    GPTQ = 1
+    LLAMA = 2
+
+
+@dataclass
+class Model:
+    model_path: str
+    model_type: ModelType
+    model_name: str
+    model_version: str
+    model_quant: str
+
+
+def list_model():
+    def parse_model_dir(model_dir):
+        with open(os.path.join(model_dir, "config.json")) as f:
+            config = json.load(f)
+            model_name = config["sakura_name"]
+            model_version = config["sakura_version"]
+            model_quant = config["sakura_quant"]
+            assert isinstance(model_name, str)
+            assert isinstance(model_version, str)
+            assert isinstance(model_quant, str)
+            return Model(
+                model_path=model_dir,
+                model_type=ModelType.GPTQ,
+                model_name=model_name,
+                model_version=model_version,
+                model_quant=model_quant,
+            )
+
+    def parse_model_file(model_file):
+        assert model_file.endswith(".gguf")
+        return Model(
+            model_path=model_file,
+            model_type=ModelType.LLAMA,
+            model_name="llama_cpp",
+            model_version="Unknown",
+            model_quant="unknown",
+        )
+
+    models: List[Model] = []
+    for model_path in os.listdir():
+        try:
+            if os.path.isdir(model_path):
+                model = parse_model_dir(model_path)
+                models.append(model)
+            elif os.path.isfile(model_path):
+                model = parse_model_file(model_path)
+                models.append(model)
+        except:
+            pass
+
+    return models
+
+
+class NoModelDialog(QtWidgets.QDialog):
+    def __init__(self, parent=None):
+        super(NoModelDialog, self).__init__(parent)
+        self.setWindowTitle("My Form")
+
+
+class ApiServerConsole(QtWidgets.QWidget):
+    models: List[Tuple[Model, QtWidgets.QRadioButton]] = []
+
+    def __init__(self):
+        super().__init__()
+
+        self.scan_button = QtWidgets.QPushButton("重新扫描模型")
+        self.scan_button.clicked.connect(self.scanModels)
+        self.toggle_button = QtWidgets.QPushButton("启动")
+        self.toggle_button.clicked.connect(self.toggleProcess)
+
+        self.vbox = QtWidgets.QVBoxLayout()
+        self.scanModels()
+        self.vbox.addStretch(1)
+        self.vbox.addWidget(self.scan_button)
+        self.vbox.addWidget(self.toggle_button)
+
+        self.process = QtCore.QProcess()
+        self.process.stateChanged.connect(self.onProcessStateChanged)
+        self.process.readyReadStandardOutput.connect(self.onReadyReadStandardOutput)
+        self.process.readyReadStandardError.connect(self.onReadyReadStandardError)
+        self.terminal = QtWidgets.QTextBrowser()
+        # 使用等宽字体
+        fixed_font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
+        fixed_font.setFixedPitch(True)
+        self.terminal.setFont(fixed_font)
+
+        hbox = QtWidgets.QHBoxLayout()
+        hbox.addLayout(self.vbox)
+        hbox.addWidget(self.terminal)
+
+        self.setLayout(hbox)
+
+        self.setGeometry(300, 300, 800, 250)
+        self.setWindowTitle("Sakrua Api 启动器")
+        self.show()
+
+    def closeEvent(self, event):
+        self.process.kill()
+        self.process.waitForFinished()
+        event.accept()
+
+    @QtCore.Slot()
+    def onReadyReadStandardOutput(self):
+        output = self.process.readAllStandardOutput().data().decode()
+        self.terminal.insertPlainText(output)
+
+    @QtCore.Slot()
+    def onReadyReadStandardError(self):
+        error = self.process.readAllStandardError().data().decode()
+        self.terminal.insertPlainText(error)
+
+    @QtCore.Slot()
+    def onProcessStateChanged(self, state):
+        running = state != QtCore.QProcess.NotRunning
+        self.toggle_button.setText("关闭" if running else "启动")
+        for _, button in self.models:
+            button.setDisabled(running)
+        self.scan_button.setDisabled(running)
+
+    @QtCore.Slot()
+    def scanModels(self):
+        for _, button in self.models:
+            button.deleteLater()
+
+        self.models = []
+        for index, model in enumerate(list_model()):
+            button = QtWidgets.QRadioButton(model.model_path)
+            button.setChecked(index == 0)
+            self.vbox.insertWidget(index, button)
+            self.models.append((model, button))
+
+    @QtCore.Slot()
+    def toggleProcess(self):
+        if self.running():
+            self.closeApiServer()
+        else:
+            selected_model = self.selectedModel()
+            if selected_model is None:
+                msgBox = QtWidgets.QMessageBox()
+                msgBox.setWindowTitle(" ")
+                msgBox.setText("启动失败:没有选中模型")
+                msgBox.exec()
+                return
+            self.terminal.clear()
+            self.startApiServer(selected_model)
+
+    def running(self):
+        return self.process.state() != QtCore.QProcess.NotRunning
+
+    def selectedModel(self):
+        for model, button in self.models:
+            if button.isChecked():
+                return model
+        return None
+
+    def startApiServer(self, model: Model):
+        command_parts = [
+            "python",
+            "server.py",
+            f"--model_name_or_path " + os.path.join(".", model.model_path),
+            "--trust_remote_code",
+            "--no-auth",
+            "--log info",
+        ]
+
+        if model.model_type == ModelType.LLAMA:
+            command_parts.append("--model_version 0.8")
+            command_parts.append("--llama_cpp")
+        elif model.model_type == ModelType.GPTQ:
+            command_parts.append("--model_version " + model.model_version)
+            if model.model_quant != "":
+                command_parts.append("--use_gptq_model")
+
+        if os.getenv("DRY_RUN", "false") == "true":
+            command_parts.append("--dry_run")
+
+        command = " ".join(command_parts)
+        print(command)
+        self.process.startCommand(command)
+
+    def closeApiServer(self):
+        self.process.kill()
+
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    console = ApiServerConsole()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/server_launcher.py
+++ b/server_launcher.py
@@ -41,7 +41,7 @@ def list_model():
             )
 
     def parse_model_file(model_file):
-        assert model_file.endswith(".gguf")
+        assert model_file.endswith(".gguf") or model_file.endswith(".ggml")
         return Model(
             model_path=model_file,
             model_type=ModelType.LLAMA,


### PR DESCRIPTION
增加了一个GUI启动器，来启动API Server。

主要功能：

1. **扫描当前文件夹下的模型文件生成模型列表**
   - 扫描模型文件的逻辑如下：
     - 扫描所有文件夹，检测文件夹下的config.json文件，如果其中存在`sakura_name`、`sakura_version`、`sakura_quant`字段且类型是字符串，则判断为模型文件夹。
     - 扫描所有文件，如果文件扩展名是`.gguf`或` .ggml`，则判断为模型文件。
   - 不提供选择模型文件的功能。
   - 不提供自动下载模型文件的功能。考虑到模型文件的大小和国内网络，自动下载模型不适合GUI用户。
2. **显示模型输出结果**
   - 删除颜色代码。因为Qt会使用系统主题，颜色不可控，彩色输出很丑。
   - stdout和stderr不做区分直接显示。
   - 使用等宽字体。
3. **当设置环境变量`DRY_RUN=true`时，使用`--dry_run`**

可能存在的问题：

1. 目前`server.py`的输出内容似乎都是通过stderr输出的，如果有内容从stdout输出，可能会因为flush时间不同导致显示顺序变化。
2. LLaMA模型无法获取版本信息。
3. LLaMA模型不能设置更详细的参数，例如：`--llama_cpp`、`--use_gpu`、`--n_gpu_layers`。