### PR TITLE
Fix multi-GPUs inference

### DIFF
--- a/utils/model.py
+++ b/utils/model.py
@@ -83,10 +83,11 @@ def load_model(args: SakuraModelConfig):
     if args.use_gptq_model:
         model = AutoGPTQForCausalLM.from_quantized(
             args.model_name_or_path,
-            device="cuda:0",
+            device_map="auto",
             trust_remote_code=args.trust_remote_code,
             use_safetensors=False,
             use_triton=False,
+            low_cpu_mem_usage=True,
         )
     elif args.llama:
         model = LlamaForCausalLM.from_pretrained(args.model_name_or_path, device_map="auto", trust_remote_code=args.trust_remote_code)


### PR DESCRIPTION
- 修复多卡环境下 `utils/model.py` 只在GPU0加载GPTQ模型的BUG
- 启用`low_cpu_mem_usage`, 减少模型加载时的内存占用