### PR TITLE
Support Ollama backend.

### DIFF
--- a/api/legacy/type.py
+++ b/api/legacy/type.py
@@ -133,8 +133,9 @@ class OpenAIChatCompletionResponse(BaseModel):
         message: Message
     class Usage(BaseModel):
         completion_tokens: int
-        prompt_tokens: int
-        total_tokens: int
+        # FIXME(kuriko): prompt_tokens may be None
+        prompt_tokens: int|None
+        total_tokens: int|None
 
     choices: List[Choice]
     created: int

--- a/api/openai/v1/chat.py
+++ b/api/openai/v1/chat.py
@@ -35,6 +35,14 @@ def get_output(data: OpenAIChatCompletionRequest) -> OpenAIChatCompletionRespons
     # await asyncio.sleep(600)
 
     logger.info(f"answer: {output}")
+
+    prompt_tokens = output.prompt_token
+    new_tokens = output.new_token
+
+    total_tokens = None
+    if prompt_tokens is not None:
+        total_tokens = new_tokens + prompt_tokens
+
     return OpenAIChatCompletionResponse(
         choices=[
             OpenAIChatCompletionResponse.Choice(
@@ -51,9 +59,9 @@ def get_output(data: OpenAIChatCompletionRequest) -> OpenAIChatCompletionRespons
         model=f"{model.cfg.model_name}-{model.cfg.model_version}-{model.cfg.model_quant}",
         object="chat.completion",
         usage=OpenAIChatCompletionResponse.Usage(
-            completion_tokens=output.new_token,
-            prompt_tokens=output.prompt_token,
-            total_tokens=output.new_token + output.prompt_token
+            completion_tokens=new_tokens,
+            prompt_tokens=prompt_tokens,
+            total_tokens=total_tokens,
         )
     )
 

--- a/requirements.ollama.txt
+++ b/requirements.ollama.txt
@@ -1,0 +1,8 @@
+-r requirements/server.txt
+--extra-index-url https://download.pytorch.org/whl/cu121
+# --extra-index-url https://download.pytorch.org/whl/cu118
+torch>=2.1.0
+transformers==4.33.2
+scipy
+numpy
+ollama

--- a/tests/example_openai.py
+++ b/tests/example_openai.py
@@ -5,7 +5,7 @@ from openai import OpenAI
 # client = OpenAI(api_key="114514", base_url=f"http://{auth}@localhost:5000/v1")
 
 # Not using auth
-api_base_url = "http://localhost:8080/v1"
+api_base_url = "http://localhost:5000/v1"
 client = OpenAI(api_key="114514", base_url=api_base_url) # api_key随便填无所谓，base_url填写服务器IP和端口并添加/v1
 
 input_text = """先程から何度も込められているため息に、確実に実体験からくる言葉だと分かって周としては胸が痛い。彼女にとって好意も悪意も向けられるのを慣れすぎている事が透けて見えて、やるせなさに唇を嚙んでしまう。

--- a/usage.md
+++ b/usage.md
@@ -46,7 +46,7 @@ vLLM 是一个快速且易于使用的 LLM 分布式推理和服务库。
 5. 与 HuggingFace Transformers 模型无缝集成。
 
 劣势：
-1. Sakura13B v0.9 与 v0.10 仅能运行全量模型，显存用量高于 llama.cpp 与 ollama。
+1. Sakura13B v0.9 与 v0.10 仅能运行全量模型（目前 SakuraLLM 未提供量化模型），显存用量高于 llama.cpp 与 ollama。
 2. 仅支持 4bit 量化，且量化存在 bug，效果不如直接运行全量模型。
 3. 由于存在部分依赖冲突，依赖安装相对繁琐。
 
@@ -112,7 +112,7 @@ python server.py \
 <!-- // 这部分写 ollama 支持加载哪些模型，如果是非 SakuraLLM 支持的格式的话，哪些地方能找到第三方维护的转换后的格式。 -->
 ollama 私有格式模型，可从 GGUF 和 PyTorch/Safetensors 格式模型进行转换，转换方法参见 [issue #49](https://github.com/SakuraLLM/Sakura-13B-Galgame/issues/49) 与 [ollama 文档](https://github.com/ollama/ollama/blob/main/docs/import.md)。
 
-Sakura 相关模型地址：
+Sakura 相关模型地址（第三方维护）：
 - [onekuma/sakura-13b-lnovel-v0.9b-q2_k](https://registry.ollama.ai/onekuma/sakura-13b-lnovel-v0.9b-q2_k/tags)
 
 ### 前置需求
@@ -138,7 +138,7 @@ python server.py \
 <!-- // 这部分写一下 ollama 模型用到了哪些参数，由于早期设计问题，server.py 没有对参数归类，导致混杂在一起了。 -->
 ```shell
 # 通用参数
---model_name_or_path: ollama 模型 tag
+--model_name_or_path: ollama 模型 tag (不支持文件路径)
 --model_version: 0.9
 --no-auth: 强制禁用身份验证
 

--- a/usage.md
+++ b/usage.md
@@ -24,8 +24,12 @@ python server.py \
 ### server.py 相关参数及说明
 <!-- // 这部分写一下推理引擎用到了哪些参数，由于早期设计问题，server.py 没有对参数归类，导致混杂在一起了。 -->
 ```shell
+# 通用参数
 --model_name_or_path: GGUF 模型路径
 --model_version: 0.9, 0.8
+--no-auth: 强制禁用身份验证
+
+# llama.cpp 特有参数
 --llama_cpp: 启动 llama.cpp 推理引擎
 --use_gpu: llama.cpp 使用 GPU 进行推理
 --n_gpu_layers: 加载至 GPU 的模型层数
@@ -62,10 +66,10 @@ Transformers 模型（包括 GPTQ 4bit 量化与 AWQ 量化）。
    ```
 
 ### 使用例子
-以运行 [SakuraLLM/Sakura-13B-Qwen2beta-v0.10pre0](https://huggingface.co/SakuraLLM/Sakura-13B-Qwen2beta-v0.10pre0) 模型为例：
+以运行 [SakuraLLM/Sakura-13B-LNovel-v0.9](https://huggingface.co/SakuraLLM/Sakura-13B-LNovel-v0.9) 模型为例：
 ```python
 python server.py \
-    --model_name_or_path SakuraLLM/Sakura-13B-Qwen2beta-v0.10pre0 \
+    --model_name_or_path SakuraLLM/Sakura-13B-LNovel-v0.9 \
     --vllm \
     --model_version 0.9 \
     --trust_remote_code \
@@ -77,8 +81,15 @@ python server.py \
 ### server.py 相关参数及说明
 <!-- // 这部分写一下推理引擎用到了哪些参数，由于早期设计问题，server.py 没有对参数归类，导致混杂在一起了。 -->
 ```shell
+# 通用参数
 --model_name_or_path: transformers 模型 tag
 --model_version: 0.9, 0.8
+--use_gptq_model: 使用 GPTQ 量化模型
+--use_awq_model: 使用 AWQ 量化模型
+--trust_remote_code: 允许不安全代码
+--no-auth: 强制禁用身份验证
+
+# vllm 特有参数
 --vllm: 启动 vllm 推理引擎
 --enforce_eager: 启用 eager 模式，可减少显存用量
 --tensor_parallel_size: tensor parallel 的规模，一般取可用的 GPU 数量
@@ -126,7 +137,11 @@ python server.py \
 ### server.py 相关参数及说明
 <!-- // 这部分写一下 ollama 模型用到了哪些参数，由于早期设计问题，server.py 没有对参数归类，导致混杂在一起了。 -->
 ```shell
+# 通用参数
 --model_name_or_path: ollama 模型 tag
 --model_version: 0.9
+--no-auth: 强制禁用身份验证
+
+# ollama 特有参数
 --ollama: 启动 ollama 推理引擎
 ```

--- a/usage.md
+++ b/usage.md
@@ -1,0 +1,132 @@
+# 各种推理引擎的使用说明
+
+* [llama-cpp-python](#llama-cpp-python)
+* [vllm](#vllm)
+* [ollama](#ollama)
+
+## llama-cpp-python
+### 支持的模型类型
+<!-- // 这部分写支持加载哪些模型，如果是非 SakuraLLM 支持的格式的话，哪些地方能找到第三方维护的转换后的格式。 -->
+GGUF 量化模型。
+
+### 使用例子
+以运行 [sakura-13b-lnovel-v0.9b-Q4_K_M.gguf](https://huggingface.co/SakuraLLM/Sakura-13B-LNovel-v0.9b-GGUF) 模型为例：
+```python
+python server.py \
+    --model_name_or_path ./models/sakura-13b-lnovel-v0.9b-Q4_K_M.gguf \
+    --llama_cpp \
+    --use_gpu \
+    --model_version 0.9 \
+    --trust_remote_code \
+    --no-auth
+```
+
+### server.py 相关参数及说明
+<!-- // 这部分写一下推理引擎用到了哪些参数，由于早期设计问题，server.py 没有对参数归类，导致混杂在一起了。 -->
+```shell
+--model_name_or_path: GGUF 模型路径
+--model_version: 0.9, 0.8
+--llama_cpp: 启动 llama.cpp 推理引擎
+--use_gpu: llama.cpp 使用 GPU 进行推理
+--n_gpu_layers: 加载至 GPU 的模型层数
+```
+
+## vllm
+vLLM 是一个快速且易于使用的 LLM 分布式推理和服务库。
+
+优势：
+1. 支持 PagedAttention。
+2. 支持 tensor parallel 多 GPU 推理加速。
+3. 支持 GPTQ, AWQ, SqueezeLLM, FP8 KV Cache 等量化方法。
+4. 支持 NVIDIA GPU 和 AMD GPU（实验性，未测试）。
+5. 与 HuggingFace Transformers 模型无缝集成。
+
+劣势：
+1. Sakura13B v0.9 与 v0.10 仅能运行全量模型，显存用量高于 llama.cpp 与 ollama。
+2. 仅支持 4bit 量化，且量化存在 bug，效果不如直接运行全量模型。
+3. 由于存在部分依赖冲突，依赖安装相对繁琐。
+
+### 支持的模型类型
+<!-- // 这部分写支持加载哪些模型，如果是非 SakuraLLM 支持的格式的话，哪些地方能找到第三方维护的转换后的格式。 -->
+Transformers 模型（包括 GPTQ 4bit 量化与 AWQ 量化）。
+
+### 前置需求
+<!-- // 这部分写除了 `requirements.txt` 中 package 依赖以外的依赖。 -->
+1. 首先运行以下命令安装 vllm 库（必须先运行这一步，否则会有依赖冲突导致无法安装）：
+   ```shell
+   pip install vllm
+   ```
+2. 运行以下命令安装运行 vllm 后端的其余依赖库：
+   ```shell
+   pip install -r requirements.vllm.txt
+   ```
+
+### 使用例子
+以运行 [SakuraLLM/Sakura-13B-Qwen2beta-v0.10pre0](https://huggingface.co/SakuraLLM/Sakura-13B-Qwen2beta-v0.10pre0) 模型为例：
+```python
+python server.py \
+    --model_name_or_path SakuraLLM/Sakura-13B-Qwen2beta-v0.10pre0 \
+    --vllm \
+    --model_version 0.9 \
+    --trust_remote_code \
+    --no-auth \
+    --tensor_parallel_size 2 \
+    --enforce_eager
+```
+
+### server.py 相关参数及说明
+<!-- // 这部分写一下推理引擎用到了哪些参数，由于早期设计问题，server.py 没有对参数归类，导致混杂在一起了。 -->
+```shell
+--model_name_or_path: transformers 模型 tag
+--model_version: 0.9, 0.8
+--vllm: 启动 vllm 推理引擎
+--enforce_eager: 启用 eager 模式，可减少显存用量
+--tensor_parallel_size: tensor parallel 的规模，一般取可用的 GPU 数量
+--gpu_memory_utilization: 0~1, vllm 推理引擎可用的每个 GPU 显存比例
+```
+
+## ollama
+
+### 介绍
+原项目地址：[ollama/ollama](https://github.com/ollama/ollama)
+
+优势：
+1. 安装运行简便，使用 docker 对模型进行管理。
+2. 对于 kaggle 环境，从 [ollama library](https://ollama.com/library) 拉取模型速度快于 huggingface 仓库，可进行 API Server 快速部署。
+
+劣势：
+1. 使用 ollama 私有格式模型，需要对 gguf 和 PyTorch/Safetensors 格式模型进行转换。
+
+### 支持的模型类型
+<!-- // 这部分写 ollama 支持加载哪些模型，如果是非 SakuraLLM 支持的格式的话，哪些地方能找到第三方维护的转换后的格式。 -->
+ollama 私有格式模型，可从 GGUF 和 PyTorch/Safetensors 格式模型进行转换，转换方法参见 [issue #49](https://github.com/SakuraLLM/Sakura-13B-Galgame/issues/49) 与 [ollama 文档](https://github.com/ollama/ollama/blob/main/docs/import.md)。
+
+Sakura 相关模型地址：
+- [onekuma/sakura-13b-lnovel-v0.9b-q2_k](https://registry.ollama.ai/onekuma/sakura-13b-lnovel-v0.9b-q2_k/tags)
+
+### 前置需求
+<!-- // 这部分写除了 `requirements.txt` 中 package 依赖以外的依赖。 -->
+1. 从[ollama 官网](https://registry.ollama.ai/download)下载并安装 ollama 程序，用于自动下载 ollama 模型。
+2. 运行以下命令安装运行 ollama 后端的依赖库：
+   ```shell
+   pip install -r requirements.ollama.txt
+   ```
+
+### 使用例子
+以运行 [onekuma](https://registry.ollama.ai/onekuma) 维护的 [sakura-13b-lnovel-v0.9b-q2_k](https://registry.ollama.ai/onekuma/sakura-13b-lnovel-v0.9b-q2_k/tags) 模型为例：
+```python
+python server.py \
+    --model_name_or_path onekuma/sakura-13b-lnovel-v0.9b-q2_k \
+    --ollama \
+    --model_version 0.9 \
+    --trust_remote_code \
+    --no-auth
+```
+
+### server.py 相关参数及说明
+<!-- // 这部分写一下 ollama 模型用到了哪些参数，由于早期设计问题，server.py 没有对参数归类，导致混杂在一起了。 -->
+```shell
+--model_name_or_path: ollama 模型 tag
+--model_version: 0.9
+--ollama: 启动 ollama 推理引擎
+```

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -32,6 +32,8 @@ def parse_args(do_validation:bool=False, add_extra_args_fn:any=None):
     parser.add_argument("--tensor_parallel_size", type=int, default=1, help="tensor parallel size when using gpu in vllm.")
     parser.add_argument("--gpu_memory_utilization", type=float, default=0.9, help="The ratio (between 0 and 1) of GPU memory for inference.")
 
+    parser.add_argument("--ollama", action="store_true", help="whether to use ollama.")
+
     if add_extra_args_fn:
         add_extra_args_fn(parser)
 

--- a/utils/model.py
+++ b/utils/model.py
@@ -402,7 +402,12 @@ class SakuraModel:
 
         # FIXME(Isotr0py): According to the #2068 issue of ollama (https://github.com/ollama/ollama/issues/2068),
         # prompt_eval_count may disappear.
-        input_tokens_len = output["prompt_eval_count"]
+        if "prompt_eval_count" not in output:
+            # FIXME(kuriko): Just guessing the token count, anti-degen may fail
+            input_tokens_len = len(prompt) // 2
+            logger.warning(f"prompt_eval_count is missing, guessing count: {input_tokens_len}")
+        else:
+            input_tokens_len = output["prompt_eval_count"]
         new_tokens = output['eval_count']
         return response, (input_tokens_len, new_tokens)
 

--- a/utils/model.py
+++ b/utils/model.py
@@ -149,7 +149,7 @@ def load_model(args: SakuraModelConfig):
 
     logger.info("loading model ...")
 
-    if not args.llama_cpp:
+    if not (args.llama_cpp or args.ollama):
         if args.llama:
             tokenizer = LlamaTokenizer.from_pretrained(args.model_name_or_path, trust_remote_code=args.trust_remote_code)
         else:

--- a/utils/model.py
+++ b/utils/model.py
@@ -646,7 +646,7 @@ class SakuraModel:
             if self.cfg.llama_cpp:
                 output, (input_tokens_len, new_tokens) = self.__llama_cpp_model(model, prompt, generation_config)
             elif self.cfg.ollama:
-                output, (input_tokens_len, new_tokens) = self.__ollama_model(model, prompt, backup_generation_config[stage-1])
+                output, (input_tokens_len, new_tokens) = self.__ollama_model(model, prompt, generation_config)
             elif self.cfg.vllm:
                 output, (input_tokens_len, new_tokens) = self.__vllm_model(model, prompt, generation_config)
             else:

--- a/utils/model.py
+++ b/utils/model.py
@@ -83,7 +83,7 @@ def load_model(args: SakuraModelConfig):
             '''Llama-style wrapper for ollama'''
             def __init__(self, model):
                 self.model = model
-                ollama.pull()
+                self.pull()
 
             def __call__(self, prompt, **kwargs):
                 return ollama.generate(self.model, prompt, **kwargs)

--- a/utils/model.py
+++ b/utils/model.py
@@ -208,6 +208,12 @@ def get_llama_cpp_metadata(args: SakuraModelConfig):
     model_name = "-".join(metadata[:-2])
     return model_name, model_version, model_quant
 
+def get_ollama_metadata(args: SakuraModelConfig):
+    metadata = args.model_name_or_path.split("-")
+    model_version, model_quant = metadata[-2], metadata[-1]
+    model_name = "-".join(metadata[:-2])
+    return model_name, model_version, model_quant
+
 class SakuraModel:
     # typing
     class ModelResponse(BaseModel):
@@ -252,7 +258,12 @@ class SakuraModel:
 
             else:
                 # FIXME(kuriko): for llama_cpp model, we cannot decide so hard coded here.
-                model_name, model_version, model_quant = get_llama_cpp_metadata(self.cfg)
+                if self.cfg.llama_cpp:
+                    model_name, model_version, model_quant = get_llama_cpp_metadata(self.cfg)
+                elif self.cfg.ollama:
+                    model_name, model_version, model_quant = get_ollama_metadata(self.cfg)
+                else:
+                    pass
 
             self.cfg.model_name = model_name
             self.cfg.model_version = model_version

--- a/utils/model.py
+++ b/utils/model.py
@@ -184,7 +184,7 @@ def get_ollama_metadata(args: SakuraModelConfig):
 class SakuraModel:
     # typing
     class ModelResponse(BaseModel):
-        prompt_token: int
+        prompt_token: int|None
         new_token: int
         text: str
         finish_reason: str
@@ -403,9 +403,8 @@ class SakuraModel:
         # FIXME(Isotr0py): According to the #2068 issue of ollama (https://github.com/ollama/ollama/issues/2068),
         # prompt_eval_count may disappear.
         if "prompt_eval_count" not in output:
-            # FIXME(kuriko): Just guessing the token count, anti-degen may fail
-            input_tokens_len = len(prompt) // 2
-            logger.warning(f"prompt_eval_count is missing, guessing count: {input_tokens_len}")
+            # NOTE(kuriko): Under most cases, input_tokens_len is not used.
+            input_tokens_len = None
         else:
             input_tokens_len = output["prompt_eval_count"]
         new_tokens = output['eval_count']

--- a/utils/model.py
+++ b/utils/model.py
@@ -19,11 +19,12 @@ if TYPE_CHECKING:
     from llama_cpp import Llama
     from auto_gptq import AutoGPTQForCausalLM
     from vllm import AsyncLLMEngine, LLM
+    Ollama = "Ollama"
+    MixLLMEngine = "MixLLMEngine"
 else:
     # FIXME(kuriko): try to making linting system happy
-    Llama = AutoGPTQForCausalLM = LlamaForCausalLM = MixLLMEngine = Any
+    Llama = AutoGPTQForCausalLM = LlamaForCausalLM = MixLLMEngine = Ollama = Any
 
-MixLLMEngine = Ollama = Any
 ModelTypes = AutoGPTQForCausalLM | Llama | LlamaForCausalLM | AutoModelForCausalLM | MixLLMEngine | Ollama
 
 
@@ -420,7 +421,7 @@ class SakuraModel:
             yield output['choices'][0]['text'], output['choices'][0]['finish_reason']
 
     def __ollama_model(
-        self, model: "Ollama", prompt: str, generation_config: GenerationConfig
+        self, model: Ollama, prompt: str, generation_config: GenerationConfig
     ):
         output = model(
             prompt,
@@ -433,7 +434,7 @@ class SakuraModel:
         response = output["response"]
         pprint(output)
 
-        # FIXME(Isotr0py): According to the #2068 issue of ollama (https://github.com/ollama/ollama/issues/2068), 
+        # FIXME(Isotr0py): According to the #2068 issue of ollama (https://github.com/ollama/ollama/issues/2068),
         # prompt_eval_count may disappear.
         input_tokens_len = output["prompt_eval_count"]
         new_tokens = output['eval_count']

--- a/utils/ollama.py
+++ b/utils/ollama.py
@@ -7,6 +7,10 @@ from pathlib import Path
 import ollama
 from tqdm import tqdm
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class Ollama:
     '''Llama-style wrapper for ollama'''
@@ -17,7 +21,8 @@ class Ollama:
             time.sleep(5)
             self.pull()
         else:
-            raise FileNotFoundError("ollama app not found. Have you installed it?")
+            logger.error("ollama executable not found in path. Have you installed it?")
+            exit(-1)
 
     def __call__(self, prompt, stream=False, **kwargs):
         return ollama.generate(self.model, prompt, stream=stream, options=kwargs)

--- a/utils/ollama.py
+++ b/utils/ollama.py
@@ -1,0 +1,50 @@
+import multiprocessing
+import subprocess
+import ollama
+import time
+from tqdm import tqdm
+
+
+class Ollama:
+    '''Llama-style wrapper for ollama'''
+    def __init__(self, model):
+        self.model = model
+        self.start()
+        time.sleep(5)  # wait for ollama serve to start
+        self.pull()
+
+    def __call__(self, prompt, stream=False, **kwargs):
+        return ollama.generate(self.model, prompt, stream=stream, options=kwargs)
+
+    def pull(self):
+        current_digest, bars = "", {}
+        for progress in ollama.pull(self.model, stream=True):
+            digest = progress.get("digest", "")
+            if digest != current_digest and current_digest in bars:
+                bars[current_digest].close()
+            if not digest:
+                print(progress.get("status"))
+                continue
+            if digest not in bars and (total := progress.get("total")):
+                bars[digest] = tqdm(
+                    total=total,
+                    desc=f"pulling {digest[7:19]}",
+                    unit="B",
+                    unit_scale=True,
+                )
+            if completed := progress.get("completed"):
+                bars[digest].update(completed - bars[digest].n)
+            current_digest = digest
+
+    def start(self):
+        proc = multiprocessing.Process(target=ollama_serve)
+        proc.start()
+
+
+def ollama_serve():
+    try:
+        p = subprocess.Popen(["ollama", "serve"], stdout=subprocess.PIPE)
+        for line in p.stdout:
+            print(line.decode(), end='')
+    except FileNotFoundError:
+        raise FileNotFoundError("ollama app not found. Have you installed it?")


### PR DESCRIPTION
Related issue:
- #49

Features:
- Support `Ollama` backend for server.
- Support auto pulling model from ollama's model repo like [onekuma/sakura-13b-lnovel-v0.9b-q2_k](https://ollama.com/onekuma/sakura-13b-lnovel-v0.9b-q2_k)

TODO:
- [x] Test ollama auto pulling from [onekuma/sakura-13b-lnovel-v0.9b-q2_k](https://ollama.com/onekuma/sakura-13b-lnovel-v0.9b-q2_k).
- [x] Test model loading and inference.

~~Still have some bugs, marked as draft.~~

Deploy (ollama need to be installed before running):
```
python server.py \
    --model_name_or_path onekuma/sakura-13b-lnovel-v0.9b-q2_k \
    --ollama \
    --model_version 0.9 \
    --trust_remote_code \
    --no-auth
```